### PR TITLE
remove duplicate element in TESTS array

### DIFF
--- a/koans.cr
+++ b/koans.cr
@@ -8,7 +8,6 @@ TESTS = %w(
   nil
   regular_expressions
   enums
-  sets
   arrays
   tuples
   named_tuples


### PR DESCRIPTION
Somewhat hilariously, `sets` appears twice in the `TESTS` array. I figure it doesn't make sense to introduce them before arrays, so I removed that one and left the one that appears just before hashes.