### PR TITLE
skip previously passed topics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /lib/watch
 /lib/.shards.info
 /.shards/
+/.cache

--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ the [Crystal Programming Language](https://crystal-lang.org/).
 - [Daniel Sokil](https://github.com/s0kil)
 - [Dorian Marié](https://github.com/dorianmariefr)
 - [Jack Kavanagh](https://github.com/jackkav)
+- [collidedscope](https://github.com/collidedscope)

--- a/koans.cr
+++ b/koans.cr
@@ -39,22 +39,33 @@ TESTS = %w(
   csv
 )
 
-PASSED_FILE = ".passed"
-passed = [] of String
+CACHE_DIR = ".cache"
+Dir.mkdir_p(CACHE_DIR)
+
+PASSED_FILE = File.join(CACHE_DIR, "passed")
+passed = {} of String => Int64
 
 if File.exists?(PASSED_FILE)
-  passed = File.read_lines(PASSED_FILE)
+  File.each_line(PASSED_FILE) do |line|
+    test_case, timestamp = line.split
+    passed[test_case] = timestamp.to_i64
+  end
 else
   File.touch(PASSED_FILE)
 end
 
 TESTS.each_with_index(1) do |test_case, test_number|
-  next if passed.includes?(test_case)
+  if timestamp = passed[test_case]?
+    mtime = File.info("spec/#{test_case}_spec.cr").modification_time.to_unix
+    next if timestamp > mtime
+  end
 
   puts "Level #{test_number}: testing your strength on #{test_case} ..."
   spec_process = Process.run("crystal spec spec/#{test_case}_spec.cr", shell: true, error: STDERR, output: STDOUT)
   if spec_process.success?
-    File.open(PASSED_FILE, "a", &.puts(test_case))
+    File.open(PASSED_FILE, "a") do |file|
+      file.puts "#{test_case} #{Time.local.to_unix}"
+    end
   else
     test_case_bold = test_case.colorize(:green).mode(:bold)
     print "--- \u{1F9D9} The Master says: ---\n".colorize(:yellow)

--- a/koans.cr
+++ b/koans.cr
@@ -39,10 +39,23 @@ TESTS = %w(
   csv
 )
 
+PASSED_FILE = ".passed"
+passed = [] of String
+
+if File.exists?(PASSED_FILE)
+  passed = File.read_lines(PASSED_FILE)
+else
+  File.touch(PASSED_FILE)
+end
+
 TESTS.each_with_index(1) do |test_case, test_number|
+  next if passed.includes?(test_case)
+
   puts "Level #{test_number}: testing your strength on #{test_case} ..."
   spec_process = Process.run("crystal spec spec/#{test_case}_spec.cr", shell: true, error: STDERR, output: STDOUT)
-  unless spec_process.success?
+  if spec_process.success?
+    File.open(PASSED_FILE, "a", &.puts(test_case))
+  else
     test_case_bold = test_case.colorize(:green).mode(:bold)
     print "--- \u{1F9D9} The Master says: ---\n".colorize(:yellow)
     print "\"Something is wrong. Please meditate on ".colorize(:green)


### PR DESCRIPTION
Reporting passed topics more than once slows things down considerably
for very little gain. This patch tracks passed topics in a cache file
and skips them when reporting the path to enlightenment.